### PR TITLE
"def=>with_default_value" fixed

### DIFF
--- a/snippets/python_snippets.json
+++ b/snippets/python_snippets.json
@@ -1487,7 +1487,7 @@
   "def=>with_default_value": {
     "prefix": "def=>with_default_value",
     "body": [
-      "def name(name, lastName='john')",
+      "def name(name, last_name='john'):",
       " pass"
     ],
     "description": "Defining Function wqith default values"


### PR DESCRIPTION
fixed this function adding a colon, as well as a variable convention with snake case rather than pascal case.